### PR TITLE
feat: Add pre-commit to Github Actions workflow

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	v2 "github.com/chanzuckerberg/fogg/config/v2"
@@ -38,7 +38,7 @@ func InitConfig(project, region, bucket, table, awsProfile, owner *string, awsPr
 						Version: &awsProviderVersion,
 					},
 				},
-				TerraformVersion: util.StrPtr(defaultTerraformVersion.String()),
+				TerraformVersion: util.Ptr(defaultTerraformVersion.String()),
 			},
 		},
 		Accounts: map[string]v2.Account{},
@@ -56,7 +56,7 @@ func FindConfig(fs afero.Fs, configFile string) ([]byte, int, error) {
 	}
 	defer f.Close()
 
-	b, e := ioutil.ReadAll(f)
+	b, e := io.ReadAll(f)
 	if e != nil {
 		return nil, 0, errs.WrapUser(e, "unable to read config")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,13 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getPtr(val string) *string {
-	return &val
-}
-
 func TestInitConfig(t *testing.T) {
 	r := require.New(t)
-	c := InitConfig(getPtr("proj"), getPtr("reg"), getPtr("buck"), getPtr("table"), getPtr("prof"), getPtr("me@foo.example"), "0.99.0")
+	c := InitConfig(util.Ptr("proj"), util.Ptr("reg"), util.Ptr("buck"), util.Ptr("table"), util.Ptr("prof"), util.Ptr("me@foo.example"), "0.99.0")
 	r.Equal("prof", *c.Defaults.Common.Backend.Profile)
 	r.Equal("prof", *c.Defaults.Providers.AWS.Profile)
 	r.Equal("reg", *c.Defaults.Providers.AWS.Region)

--- a/config/v2/resolvers.go
+++ b/config/v2/resolvers.go
@@ -188,7 +188,7 @@ func ResolveBackend(commons ...Common) *Backend {
 	for _, c := range commons {
 		if c.Backend != nil {
 			if ret == nil {
-				ret = &Backend{Kind: util.StrPtr("s3")}
+				ret = &Backend{Kind: util.Ptr("s3")}
 			}
 			b := c.Backend
 			if b.Kind != nil {

--- a/plan/ci.go
+++ b/plan/ci.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v2 "github.com/chanzuckerberg/fogg/config/v2"
+	"github.com/chanzuckerberg/fogg/util"
 	atlantis "github.com/runatlantis/atlantis/server/core/config/raw"
 )
 
@@ -356,11 +357,6 @@ func (p *Plan) buildGitHubActionsConfig(c *v2.Config, foggVersion string) GitHub
 	}
 }
 
-// golang 1.18+ generics
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 // buildAtlantisConfig must be build after Envs
 func (p *Plan) buildAtlantisConfig(c *v2.Config, foggVersion string) AtlantisConfig {
 	enabled := false
@@ -388,13 +384,13 @@ func (p *Plan) buildAtlantisConfig(c *v2.Config, foggVersion string) AtlantisCon
 				}
 
 				projects = append(projects, atlantis.Project{
-					Name:              Ptr(fmt.Sprintf("%s_%s", envName, cName)),
-					Dir:               Ptr(fmt.Sprintf("terraform/envs/%s/%s", envName, cName)),
-					TerraformVersion:  &d.Common.TerraformVersion,
-					Workspace:         Ptr(atlantis.DefaultWorkspace),
+					Name:              util.Ptr(fmt.Sprintf("%s_%s", envName, cName)),
+					Dir:               util.Ptr(fmt.Sprintf("terraform/envs/%s/%s", envName, cName)),
+					TerraformVersion:  &d.ComponentCommon.TerraformVersion,
+					Workspace:         util.Ptr(atlantis.DefaultWorkspace),
 					ApplyRequirements: []string{atlantis.ApprovedApplyRequirement},
 					Autoplan: &atlantis.Autoplan{
-						Enabled:      Ptr(true),
+						Enabled:      util.Ptr(true),
 						WhenModified: whenModified,
 					},
 				})

--- a/plan/ci_test.go
+++ b/plan/ci_test.go
@@ -53,28 +53,28 @@ func Test_buildTravisCI_Profiles(t *testing.T) {
 		Version: 2,
 		Defaults: v2.Defaults{
 			Common: v2.Common{
-				Project:          util.StrPtr("foo"),
-				Owner:            util.StrPtr("bar"),
-				TerraformVersion: util.StrPtr("0.1.0"),
+				Project:          util.Ptr("foo"),
+				Owner:            util.Ptr("bar"),
+				TerraformVersion: util.Ptr("0.1.0"),
 				Providers: &v2.Providers{
 					AWS: &v2.AWSProvider{
 						AccountID: util.JSONNumberPtr(123),
-						Region:    util.StrPtr("us-west-2"),
-						Profile:   util.StrPtr("foo"),
-						Version:   util.StrPtr("0.12.0"),
+						Region:    util.Ptr("us-west-2"),
+						Profile:   util.Ptr("foo"),
+						Version:   util.Ptr("0.12.0"),
 					},
 				},
 				Backend: &v2.Backend{
-					Bucket:    util.StrPtr("bucket"),
-					Region:    util.StrPtr("us-west-2"),
-					Profile:   util.StrPtr("profile"),
-					AccountID: util.StrPtr("some account id"),
+					Bucket:    util.Ptr("bucket"),
+					Region:    util.Ptr("us-west-2"),
+					Profile:   util.Ptr("profile"),
+					AccountID: util.Ptr("some account id"),
 				},
 				Tools: &v2.Tools{
 					TravisCI: &v2.TravisCI{
 						CommonCI: v2.CommonCI{
 							Enabled:        &tr,
-							AWSIAMRoleName: util.StrPtr("rollin"),
+							AWSIAMRoleName: util.Ptr("rollin"),
 						},
 					}},
 			},
@@ -109,27 +109,27 @@ func Test_buildTravisCI_TestBuckets(t *testing.T) {
 		Version: 2,
 		Defaults: v2.Defaults{
 			Common: v2.Common{
-				Project:          util.StrPtr("foo"),
-				Owner:            util.StrPtr("bar"),
-				TerraformVersion: util.StrPtr("0.1.0"),
+				Project:          util.Ptr("foo"),
+				Owner:            util.Ptr("bar"),
+				TerraformVersion: util.Ptr("0.1.0"),
 				Providers: &v2.Providers{
 					AWS: &v2.AWSProvider{
 						AccountID: util.JSONNumberPtr(123),
-						Region:    util.StrPtr("us-west-2"),
-						Profile:   util.StrPtr("foo"),
-						Version:   util.StrPtr("0.12.0"),
+						Region:    util.Ptr("us-west-2"),
+						Profile:   util.Ptr("foo"),
+						Version:   util.Ptr("0.12.0"),
 					},
 				},
 				Backend: &v2.Backend{
-					Bucket:    util.StrPtr("bucket"),
-					Region:    util.StrPtr("us-west-2"),
-					Profile:   util.StrPtr("profile"),
-					AccountID: util.StrPtr("some account id"),
+					Bucket:    util.Ptr("bucket"),
+					Region:    util.Ptr("us-west-2"),
+					Profile:   util.Ptr("profile"),
+					AccountID: util.Ptr("some account id"),
 				},
 				Tools: &v2.Tools{TravisCI: &v2.TravisCI{
 					CommonCI: v2.CommonCI{
 						Enabled:        &tr,
-						AWSIAMRoleName: util.StrPtr("rollin"),
+						AWSIAMRoleName: util.Ptr("rollin"),
 					},
 				}},
 			},
@@ -165,28 +165,28 @@ func Test_buildCircleCI_Profiles(t *testing.T) {
 		Version: 2,
 		Defaults: v2.Defaults{
 			Common: v2.Common{
-				Project:          util.StrPtr("foo"),
-				Owner:            util.StrPtr("bar"),
-				TerraformVersion: util.StrPtr("0.1.0"),
+				Project:          util.Ptr("foo"),
+				Owner:            util.Ptr("bar"),
+				TerraformVersion: util.Ptr("0.1.0"),
 				Providers: &v2.Providers{
 					AWS: &v2.AWSProvider{
 						AccountID: util.JSONNumberPtr(123),
-						Region:    util.StrPtr("us-west-2"),
-						Profile:   util.StrPtr("foo"),
-						Version:   util.StrPtr("0.12.0"),
+						Region:    util.Ptr("us-west-2"),
+						Profile:   util.Ptr("foo"),
+						Version:   util.Ptr("0.12.0"),
 					},
 				},
 				Backend: &v2.Backend{
-					Bucket:    util.StrPtr("bucket"),
-					Region:    util.StrPtr("us-west-2"),
-					Profile:   util.StrPtr("profile"),
-					AccountID: util.StrPtr("some account id"),
+					Bucket:    util.Ptr("bucket"),
+					Region:    util.Ptr("us-west-2"),
+					Profile:   util.Ptr("profile"),
+					AccountID: util.Ptr("some account id"),
 				},
 				Tools: &v2.Tools{
 					CircleCI: &v2.CircleCI{
 						CommonCI: v2.CommonCI{
 							Enabled:        &tr,
-							AWSIAMRoleName: util.StrPtr("rollin"),
+							AWSIAMRoleName: util.Ptr("rollin"),
 						},
 					}},
 			},
@@ -220,28 +220,28 @@ func Test_buildCircleCI_ProfilesDisabled(t *testing.T) {
 		Version: 2,
 		Defaults: v2.Defaults{
 			Common: v2.Common{
-				Project:          util.StrPtr("foo"),
-				Owner:            util.StrPtr("bar"),
-				TerraformVersion: util.StrPtr("0.1.0"),
+				Project:          util.Ptr("foo"),
+				Owner:            util.Ptr("bar"),
+				TerraformVersion: util.Ptr("0.1.0"),
 				Providers: &v2.Providers{
 					AWS: &v2.AWSProvider{
 						AccountID: util.JSONNumberPtr(123),
-						Region:    util.StrPtr("us-west-2"),
-						Profile:   util.StrPtr("foo"),
-						Version:   util.StrPtr("0.12.0"),
+						Region:    util.Ptr("us-west-2"),
+						Profile:   util.Ptr("foo"),
+						Version:   util.Ptr("0.12.0"),
 					},
 				},
 				Backend: &v2.Backend{
-					Bucket:    util.StrPtr("bucket"),
-					Region:    util.StrPtr("us-west-2"),
-					Profile:   util.StrPtr("profile"),
-					AccountID: util.StrPtr("some account id"),
+					Bucket:    util.Ptr("bucket"),
+					Region:    util.Ptr("us-west-2"),
+					Profile:   util.Ptr("profile"),
+					AccountID: util.Ptr("some account id"),
 				},
 				Tools: &v2.Tools{
 					CircleCI: &v2.CircleCI{
 						CommonCI: v2.CommonCI{
 							Enabled:        &tr,
-							AWSIAMRoleName: util.StrPtr("rollin"),
+							AWSIAMRoleName: util.Ptr("rollin"),
 							Providers: map[string]v2.CIProviderConfig{
 								"aws": {
 									Disabled: true,

--- a/plugins/custom_plugin_test.go
+++ b/plugins/custom_plugin_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,7 +27,7 @@ func TestCustomPluginTar(t *testing.T) {
 	r.NoError(err)
 	defer os.RemoveAll(d)
 
-	cacheDir, err := ioutil.TempDir("", "")
+	cacheDir, err := os.MkdirTemp("", "")
 	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
@@ -77,7 +76,7 @@ func TestCustomPluginTarStripComponents(t *testing.T) {
 	r.NoError(err)
 	defer os.RemoveAll(d)
 
-	cacheDir, err := ioutil.TempDir("", "")
+	cacheDir, err := os.MkdirTemp("", "")
 	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
@@ -138,7 +137,7 @@ func TestCustomPluginZip(t *testing.T) {
 	r.NoError(err)
 	defer os.RemoveAll(d)
 
-	cacheDir, err := ioutil.TempDir("", "")
+	cacheDir, err := os.MkdirTemp("", "")
 	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
@@ -188,7 +187,7 @@ func TestCustomPluginBin(t *testing.T) {
 	defer os.RemoveAll(d)
 	fileContents := "some contents"
 
-	cacheDir, err := ioutil.TempDir("", "")
+	cacheDir, err := os.MkdirTemp("", "")
 	r.NoError(err)
 	defer os.RemoveAll(cacheDir)
 	cache := plugins.GetPluginCache(cacheDir)
@@ -219,7 +218,7 @@ func TestCustomPluginBin(t *testing.T) {
 	f, err := fs.Open(customPluginPath)
 	r.Nil(err)
 
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	r.Nil(err)
 	r.Equal(string(contents), fileContents)
 
@@ -232,7 +231,7 @@ func TestCustomPluginBin(t *testing.T) {
 func generateTar(t *testing.T, files []string, dirs []string) string {
 	r := require.New(t)
 
-	f, err := ioutil.TempFile("", "testing")
+	f, err := os.CreateTemp("", "testing")
 	r.Nil(err)
 	defer f.Close()
 	gw := gzip.NewWriter(f)
@@ -268,7 +267,7 @@ func generateTar(t *testing.T, files []string, dirs []string) string {
 // based on https://golangcode.com/create-zip-files-in-go/
 func generateZip(t *testing.T, files []string) string {
 	r := require.New(t)
-	f, err := ioutil.TempFile("", "testing")
+	f, err := os.CreateTemp("", "testing")
 	r.Nil(err)
 
 	defer f.Close()

--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -22,6 +22,15 @@ jobs:
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: {{`${{ secrets.GITHUB_TOKEN }}`}}
+      - uses: actions/setup-python@v3
+      - uses: mfinelli/setup-shfmt@v1
+        with:
+          shfmt-version: 3.5.1
+      - uses: rhythmictech/actions-setup-tfenv@v0.1.2
+      - uses: scottbrenner/cfn-lint-action@v2
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files || true
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -21,6 +21,15 @@ jobs:
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v3
+      - uses: mfinelli/setup-shfmt@v1
+        with:
+          shfmt-version: 3.5.1
+      - uses: rhythmictech/actions-setup-tfenv@v0.1.2
+      - uses: scottbrenner/cfn-lint-action@v2
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files || true
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -21,6 +21,15 @@ jobs:
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v3
+      - uses: mfinelli/setup-shfmt@v1
+        with:
+          shfmt-version: 3.5.1
+      - uses: rhythmictech/actions-setup-tfenv@v0.1.2
+      - uses: scottbrenner/cfn-lint-action@v2
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files || true
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A

--- a/util/module_storage_test.go
+++ b/util/module_storage_test.go
@@ -5,7 +5,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 
 func TestDownloadModule(t *testing.T) {
 	r := require.New(t)
-	dir, e := ioutil.TempDir("", "fogg")
+	dir, e := os.MkdirTemp("", "fogg")
 	r.Nil(e)
 
 	pwd, e := os.Getwd()

--- a/util/template.go
+++ b/util/template.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"io"
 	"io/fs"
 	"reflect"
@@ -47,12 +48,15 @@ func avail(name string, data interface{}) bool {
 //
 // This is designed to be called from a template.
 func toYAML(v interface{}) string {
-	data, err := yaml.Marshal(v)
+	var b bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&b)
+	yamlEncoder.SetIndent(2)
+	err := yamlEncoder.Encode(v)
 	if err != nil {
 		// Swallow errors inside of a template.
 		return ""
 	}
-	return strings.TrimSuffix(string(data), "\n")
+	return strings.TrimSuffix(b.String(), "\n")
 }
 
 // OpenTemplate will read `source` for a template, parse, configure and return a template.Template

--- a/util/testing.go
+++ b/util/testing.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,8 +10,9 @@ import (
 	"github.com/spf13/afero"
 )
 
-func Intptr(i int64) *int64 {
-	return &i
+// golang 1.18+ generics
+func Ptr[T any](v T) *T {
+	return &v
 }
 
 func JSONNumberPtr(i int) *json.Number {
@@ -36,11 +36,11 @@ func ProjectRoot() string {
 func TestFile(name string) ([]byte, error) {
 	// always look for yaml, json deprecated
 	path := filepath.Join(ProjectRoot(), "testdata", name, "fogg.yml")
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func TestFs() (afero.Fs, string, error) {
-	d, err := ioutil.TempDir("", "fogg")
+	d, err := os.MkdirTemp("", "fogg")
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
fogg apply causes problems with pre-commit, adding pre-commit to the fogg generated GitHub Action workflow prevents these problems.

Ideally the pre-commit configuration ignores the fogg changes or the fogg templates are updated to match the pre-commit expectations.

> Note: This commit also cleans up golang 1.18 deprecated libraries and tries to re-use functions to get ptr for literals from util package
