### PR TITLE
fix: fogg ci gh actions typo on tflint cache

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -100,7 +100,7 @@ jobs:
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
-          key: flint-{{`${{ hashFiles('.tflint.hcl') }}`}}
+          key: tflint-{{`${{ hashFiles('.tflint.hcl') }}`}}
       - uses: terraform-linters/setup-tflint@v2
         name: Setup TFLint
         with:


### PR DESCRIPTION
Fix typo in cache name for tflint plugins
