### PR TITLE
fix: prevent changes to .terraform-version

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -96,9 +96,11 @@ jobs:
           git-commit-message: |
             commit from fogg_ci -- ran terraform-docs and pushed
       - name: fix terraform fmt
-        working-directory: {{`${{matrix.tfmodule}}`}}
         run: |
+          pushd {{`${{matrix.tfmodule}}`}}
           make fmt
+          popd
+          git checkout .terraform-version
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -95,9 +95,11 @@ jobs:
           git-commit-message: |
             commit from fogg_ci -- ran terraform-docs and pushed
       - name: fix terraform fmt
-        working-directory: ${{matrix.tfmodule}}
         run: |
+          pushd ${{matrix.tfmodule}}
           make fmt
+          popd
+          git checkout .terraform-version
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -95,9 +95,11 @@ jobs:
           git-commit-message: |
             commit from fogg_ci -- ran terraform-docs and pushed
       - name: fix terraform fmt
-        working-directory: ${{matrix.tfmodule}}
         run: |
+          pushd ${{matrix.tfmodule}}
           make fmt
+          popd
+          git checkout .terraform-version
       - uses: EndBug/add-and-commit@v9
         with:
           add: -A


### PR DESCRIPTION
Due to some strange behaviour, tfenv seems to change the contents of .terraform-version at repo root
