### PR TITLE
fix: GitHub Actions ID Token permissions for AWS IAM Role access

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -10,6 +10,12 @@ concurrency:
 jobs:
   fogg-apply:
     runs-on: ubuntu-latest
+    {{- if not (eq (len $githubActionsCI.DefaultAWSIAMRoleName) 0) }}
+    permissions:
+      # required for GH Actions -> OIDC -> AWS
+      id-token: write
+      # required to push fixes back to repo
+      contents: write{{ end }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
@@ -9,6 +9,11 @@ concurrency:
 jobs:
   fogg-apply:
     runs-on: ubuntu-latest
+    permissions:
+      # required for GH Actions -> OIDC -> AWS
+      id-token: write
+      # required to push fixes back to repo
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -9,6 +9,11 @@ concurrency:
 jobs:
   fogg-apply:
     runs-on: ubuntu-latest
+    permissions:
+      # required for GH Actions -> OIDC -> AWS
+      id-token: write
+      # required to push fixes back to repo
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
GitHub Action Job needs access to `id-token` to assume AWS IAM Role