### PR TITLE
fix: tflint v0.47.0 fixes

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -131,4 +131,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint {{`${{matrix.tfmodule}}`}}
+          tflint --chdir {{`${{matrix.tfmodule}}`}}

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -118,4 +118,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint ${{matrix.tfmodule}}
+          tflint --chdir ${{matrix.tfmodule}}

--- a/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
@@ -128,4 +128,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint ${{matrix.tfmodule}}
+          tflint --chdir ${{matrix.tfmodule}}

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -128,4 +128,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint ${{matrix.tfmodule}}
+          tflint --chdir ${{matrix.tfmodule}}


### PR DESCRIPTION
- Command line arguments support was dropped in v0.47. Use --chdir or --filter instead.
