### PR TITLE
fix: Ensure tflint config from repo root is used in CI

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -131,4 +131,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint --chdir {{`${{matrix.tfmodule}}`}}
+          tflint --config "$(pwd)/.tflint.hcl" --chdir {{`${{matrix.tfmodule}}`}}

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -118,4 +118,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint --chdir ${{matrix.tfmodule}}
+          tflint --config "$(pwd)/.tflint.hcl" --chdir ${{matrix.tfmodule}}

--- a/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
@@ -128,4 +128,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint --chdir ${{matrix.tfmodule}}
+          tflint --config "$(pwd)/.tflint.hcl" --chdir ${{matrix.tfmodule}}

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -128,4 +128,4 @@ jobs:
         run: tflint --init
       - name: tflint
         run: |
-          tflint --chdir ${{matrix.tfmodule}}
+          tflint --config "$(pwd)/.tflint.hcl" --chdir ${{matrix.tfmodule}}


### PR DESCRIPTION
use `$(pwd)` as detailed in [tflint user guide](https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md)
