### PR TITLE
chore: Group dependabot PRs for ease of maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  labels:
-  - bot/merge
-  commit-message:
-    prefix: "chore: "
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - bot/merge
+    commit-message:
+      prefix: "chore: "
+    groups:
+      atlantis:
+        patterns:
+          - "github.com/runatlantis/*"
+      terraform:
+        patterns:
+          - "github.com/hashicorp/*"
+      gomod:
+        patterns:
+          - "*"


### PR DESCRIPTION
Ref: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/

- Group all hashicorp dependencies together
- Group all atlantis dependencies together
- Group everything else together

This may result in bigger PRs, but the groups should split by tendency to break things
