### PR TITLE
chore: bump ci templates

### DIFF
--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -1,0 +1,28 @@
+# Validates PR title follows conventional commits
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  conventional_commit_title:
+    runs-on: ubuntu-22.04
+    steps:
+      # source https://github.com/chanzuckerberg/github-actions/blob/cac0ba177b109becac01bc340a3a1547feb40fe5/.github/actions/conventional-commits/action.yml
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|PRODSEC|SECENG|ONCALL)-[0-9]+)|([a-z]+))\))?(!)?: (.)+$/
+            const title = context.payload.pull_request.title
+            const is_valid = validator.test(title)
+
+            if (!is_valid) {
+              const details = JSON.stringify({
+                title: title,
+                valid_syntax: validator.toString(),
+              })
+              core.setFailed(`Your pr title doesn't adhere to conventional commits syntax. See more details: ${details}`)
+            }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chanzuckerberg/fogg
 
-go 1.21
+go 1.21.1
 
 replace github.com/spf13/afero => github.com/chanzuckerberg/afero v0.0.0-20190514223411-36a9495a9b51
 

--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -17,7 +17,7 @@ jobs:
       # required to push fixes back to repo
       contents: write{{ end }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: {{`${{ github.event.pull_request.head.repo.full_name }}`}}
           ref: {{`${{ github.event.pull_request.head.ref }}`}}
@@ -30,15 +30,15 @@ jobs:
       - run: make setup
       {{- if not (eq (len $githubActionsCI.DefaultAWSIAMRoleName) 0) }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4.0.0
         with:
           role-to-assume: {{ $githubActionsCI.DefaultAWSIAMRoleName }}
           aws-region: {{ $githubActionsCI.DefaultAWSRegion }}{{ end }}
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: {{`${{ secrets.GITHUB_TOKEN }}`}}
-      - uses: actions/setup-python@v3
-      - uses: mfinelli/setup-shfmt@v1
+      - uses: actions/setup-python@v4
+      - uses: mfinelli/setup-shfmt@v2
         with:
           shfmt-version: 3.5.1
       - uses: rhythmictech/actions-setup-tfenv@v0.1.2
@@ -56,11 +56,11 @@ jobs:
     outputs:
       allChanges: {{`${{ steps.changedDirs.outputs.allChanges }}`}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: {{`${{ github.event.pull_request.head.repo.full_name }}`}}
           ref: {{`${{ github.event.pull_request.head.ref }}`}}
-      - uses: dorny/paths-filter@v2.10.2
+      - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:
           initial-fetch-depth: '1'
@@ -92,7 +92,7 @@ jobs:
         tfmodule: {{`${{ fromJson(needs.find-changed-dirs.outputs.allChanges) }}`}}
     if: {{`${{ needs.find-changed-dirs.outputs.allChanges != '[]' }}`}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           token: {{`${{ secrets.GITHUB_TOKEN }}`}}
           repository: {{`${{ github.event.pull_request.head.repo.full_name }}`}}
@@ -118,12 +118,12 @@ jobs:
           add: -A
           message: |
             commit from fogg_ci -- ran terraform fmt and pushed
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-{{`${{ hashFiles('.tflint.hcl') }}`}}
-      - uses: terraform-linters/setup-tflint@v2
+      - uses: terraform-linters/setup-tflint@v3
         name: Setup TFLint
         with:
           tflint_version: v0.47.0

--- a/testdata/github_actions/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions/.github/workflows/fogg_ci.yml
@@ -10,7 +10,7 @@ jobs:
   fogg-apply:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -24,8 +24,8 @@ jobs:
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v3
-      - uses: mfinelli/setup-shfmt@v1
+      - uses: actions/setup-python@v4
+      - uses: mfinelli/setup-shfmt@v2
         with:
           shfmt-version: 3.5.1
       - uses: rhythmictech/actions-setup-tfenv@v0.1.2
@@ -43,11 +43,11 @@ jobs:
     outputs:
       allChanges: ${{ steps.changedDirs.outputs.allChanges }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: dorny/paths-filter@v2.10.2
+      - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:
           initial-fetch-depth: '1'
@@ -79,7 +79,7 @@ jobs:
         tfmodule: ${{ fromJson(needs.find-changed-dirs.outputs.allChanges) }}
     if: ${{ needs.find-changed-dirs.outputs.allChanges != '[]' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -105,12 +105,12 @@ jobs:
           add: -A
           message: |
             commit from fogg_ci -- ran terraform fmt and pushed
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@v2
+      - uses: terraform-linters/setup-tflint@v3
         name: Setup TFLint
         with:
           tflint_version: v0.47.0

--- a/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
@@ -15,7 +15,7 @@ jobs:
       # required to push fixes back to repo
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -27,15 +27,15 @@ jobs:
           key: fogg-cache-${{ hashFiles('**/.fogg-version') }}
       - run: make setup
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4.0.0
         with:
           role-to-assume: infraci
           aws-region: us-east-1
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v3
-      - uses: mfinelli/setup-shfmt@v1
+      - uses: actions/setup-python@v4
+      - uses: mfinelli/setup-shfmt@v2
         with:
           shfmt-version: 3.5.1
       - uses: rhythmictech/actions-setup-tfenv@v0.1.2
@@ -53,11 +53,11 @@ jobs:
     outputs:
       allChanges: ${{ steps.changedDirs.outputs.allChanges }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: dorny/paths-filter@v2.10.2
+      - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:
           initial-fetch-depth: '1'
@@ -89,7 +89,7 @@ jobs:
         tfmodule: ${{ fromJson(needs.find-changed-dirs.outputs.allChanges) }}
     if: ${{ needs.find-changed-dirs.outputs.allChanges != '[]' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -115,12 +115,12 @@ jobs:
           add: -A
           message: |
             commit from fogg_ci -- ran terraform fmt and pushed
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@v2
+      - uses: terraform-linters/setup-tflint@v3
         name: Setup TFLint
         with:
           tflint_version: v0.47.0

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -15,7 +15,7 @@ jobs:
       # required to push fixes back to repo
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -27,15 +27,15 @@ jobs:
           key: fogg-cache-${{ hashFiles('**/.fogg-version') }}
       - run: make setup
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4.0.0
         with:
           role-to-assume: foo
           aws-region: bar
       - run: .fogg/bin/fogg apply
         env:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v3
-      - uses: mfinelli/setup-shfmt@v1
+      - uses: actions/setup-python@v4
+      - uses: mfinelli/setup-shfmt@v2
         with:
           shfmt-version: 3.5.1
       - uses: rhythmictech/actions-setup-tfenv@v0.1.2
@@ -53,11 +53,11 @@ jobs:
     outputs:
       allChanges: ${{ steps.changedDirs.outputs.allChanges }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: dorny/paths-filter@v2.10.2
+      - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:
           initial-fetch-depth: '1'
@@ -89,7 +89,7 @@ jobs:
         tfmodule: ${{ fromJson(needs.find-changed-dirs.outputs.allChanges) }}
     if: ${{ needs.find-changed-dirs.outputs.allChanges != '[]' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -115,12 +115,12 @@ jobs:
           add: -A
           message: |
             commit from fogg_ci -- ran terraform fmt and pushed
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@v2
+      - uses: terraform-linters/setup-tflint@v3
         name: Setup TFLint
         with:
           tflint_version: v0.47.0


### PR DESCRIPTION
## fix: go mod changed format

Ref:
- https://github.com/golang/go/issues/62278#issuecomment-1698829945

may require re-installing go language server after upgrading to 1.21

```sh
go install golang.org/x/tools/gopls@latest
```

or:

1. Press Ctrl Shift P
1. Select Go: Install/Update tools

## chore: bump gh action versions

| Package | From | To |
| --- | --- | --- |
| [actions/checkout](https://github.com/actions/checkout) | `2.4.0` | `4.0.0` |
| [actions/cache](https://github.com/actions/cache) | `2` | `3` |
| [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) | `1.6.1` | `4.0.0` |
| [actions/setup-python](https://github.com/actions/setup-python) | `3` | `4` |
| [mfinelli/setup-shfmt](https://github.com/mfinelli/setup-shfmt) | `1` | `2` |
| [dorny/paths-filter](https://github.com/dorny/paths-filter) | `2.10.2` | `2.11.1` |
| [terraform-linters/setup-tflint](https://github.com/terraform-linters/setup-tflint) | `2` | `3` |