### PR TITLE
fix: dependabot gomod groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,17 @@ updates:
       terraform:
         patterns:
           - "github.com/hashicorp/*"
+        exclude-patterns:
+          # pin to 0.15.3 (last version with shared registry packages)
+          - "github.com/hashicorp/terraform/*"
       gomod:
         patterns:
           - "*"
+        exclude-patterns:
+          - "github.com/runatlantis/*"
+          - "github.com/hashicorp/*"
+          # pin to 0.15.3 (last version with shared registry packages)
+          - "github.com/hashicorp/terraform/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- Ensure atlantis and terraform dependencies are excluded from the wildcard group
- Exclude terraform as v0.15.3 is the last version with public registry pkg

See Terraform [commit 718d4fd0](https://github.com/hashicorp/terraform/commits/v0.15.4/internal/registry)
