### PR TITLE
fix: Wrong fogg_ci job permissions

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -14,6 +14,7 @@ jobs:
     permissions:
       # required for GH Actions -> OIDC -> AWS
       id-token: write
+      contents: read
     {{- end }}
     steps:
       - uses: actions/checkout@v4.0.0

--- a/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
+++ b/testdata/github_actions_with_iam_role/.github/workflows/fogg_ci.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       # required for GH Actions -> OIDC -> AWS
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4.0.0
         with:

--- a/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_full_yaml/.github/workflows/fogg_ci.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       # required for GH Actions -> OIDC -> AWS
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4.0.0
         with:

--- a/testdata/v2_github_actions_with_pre_commit/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_github_actions_with_pre_commit/.github/workflows/fogg_ci.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       # required for GH Actions -> OIDC -> AWS
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4.0.0
         with:


### PR DESCRIPTION
Need to explicitly allow `contents: read` permission when specifying `id-token: write`
