### PR TITLE
fix: Filter out invalid module inputs

### DIFF
--- a/testdata/v2_tf_registry_module_atlantis/fogg.yml
+++ b/testdata/v2_tf_registry_module_atlantis/fogg.yml
@@ -37,6 +37,7 @@ envs:
               - private_subnets
               - public_subnets
               - tags
+              - banana
           - source: "terraform/modules/my_module"
 modules:
   my_module: {}

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,6 +1,10 @@
 package util
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
 
 func SliceContainsString(haystack []string, needle string) bool {
 	for _, s := range haystack {
@@ -9,6 +13,37 @@ func SliceContainsString(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func Intersect(slice1, slice2 []string, message *string) (intersection []string) {
+	elements := make(map[string]bool, len(slice1))
+	for _, item := range slice1 {
+		elements[item] = true
+	}
+	for _, item := range slice2 {
+		if elements[item] {
+			intersection = append(intersection, item)
+		} else {
+			if message != nil {
+				logrus.Warnf(*message, item)
+			}
+		}
+	}
+	return intersection
+}
+
+func Union(slice1, slice2 []string) (union []string) {
+	elements := make(map[string]bool)
+	for _, val := range slice1 {
+		elements[val] = true
+		union = append(union, val)
+	}
+	for _, val := range slice2 {
+		if !elements[val] {
+			union = append(union, val)
+		}
+	}
+	return union
 }
 
 func JoinStrPointers(sep string, elems ...*string) *string {


### PR DESCRIPTION
When variables are configured, but don't exist in module config, drop them
