### PR TITLE
chore: Don't ignore envrc file

### DIFF
--- a/templates/templates/repo/.gitignore
+++ b/templates/templates/repo/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/auth0_provider_yaml/.gitignore
+++ b/testdata/auth0_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/bless_provider_yaml/.gitignore
+++ b/testdata/bless_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/circleci/.gitignore
+++ b/testdata/circleci/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/generic_providers_yaml/.gitignore
+++ b/testdata/generic_providers_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/github_actions/.gitignore
+++ b/testdata/github_actions/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/github_actions_with_iam_role/.gitignore
+++ b/testdata/github_actions_with_iam_role/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/github_provider_yaml/.gitignore
+++ b/testdata/github_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/okta_provider_yaml/.gitignore
+++ b/testdata/okta_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/remote_backend_yaml/.gitignore
+++ b/testdata/remote_backend_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/snowflake_provider_yaml/.gitignore
+++ b/testdata/snowflake_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/tfe_config/.gitignore
+++ b/testdata/tfe_config/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/tfe_provider_yaml/.gitignore
+++ b/testdata/tfe_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_aws_default_tags/.gitignore
+++ b/testdata/v2_aws_default_tags/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_aws_ignore_tags/.gitignore
+++ b/testdata/v2_aws_ignore_tags/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_full_yaml/.gitignore
+++ b/testdata/v2_full_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_github_actions_with_pre_commit/.gitignore
+++ b/testdata/v2_github_actions_with_pre_commit/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_integration_registry/.gitignore
+++ b/testdata/v2_integration_registry/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_minimal_valid_yaml/.gitignore
+++ b/testdata/v2_minimal_valid_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_no_aws_provider_yaml/.gitignore
+++ b/testdata/v2_no_aws_provider_yaml/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_tf_registry_module/.gitignore
+++ b/testdata/v2_tf_registry_module/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals

--- a/testdata/v2_tf_registry_module_atlantis/.gitignore
+++ b/testdata/v2_tf_registry_module_atlantis/.gitignore
@@ -28,7 +28,6 @@
 
 .DS_Store
 .vscode
-.envrc
 
 # Scala language server
 .metals


### PR DESCRIPTION
`.envrc` is necessary for [direnv](https://direnv.net/)
