### PR TITLE
feat: Atlantis custom module source prefix list and CDKTF support

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -207,7 +207,13 @@ type GitHubActionsCI struct {
 }
 
 type Atlantis struct {
-	Enabled     *bool `yaml:"enabled,omitempty"`
+	// enable Atlantis integration
+	// default: false
+	Enabled *bool `yaml:"enabled,omitempty"`
+	// list of module source prefixes for auto plan when modified
+	// default: "terraform/modules/"
+	ModulePrefixes []string `yaml:"module_prefixes,omitempty"`
+	// Raw atlantis RepoCfg struct
 	raw.RepoCfg `yaml:",inline"`
 }
 

--- a/testdata/v2_tf_registry_module_atlantis/atlantis.yaml
+++ b/testdata/v2_tf_registry_module_atlantis/atlantis.yaml
@@ -11,7 +11,10 @@ projects:
       when_modified:
         - '*.tf'
         - '!remote-states.tf'
-        - ../../../modules/my_module/**/*.tf
+        - ../../../../terraform/modules/my_module/**/*.tf
+        - ../../../../terraform/modules/my_module/**/*.tf.json
+        - ../../../../foo_modules/bar/**/*.tf
+        - ../../../../foo_modules/bar/**/*.tf.json
       enabled: true
     apply_requirements:
       - approved

--- a/testdata/v2_tf_registry_module_atlantis/fogg.yml
+++ b/testdata/v2_tf_registry_module_atlantis/fogg.yml
@@ -10,6 +10,9 @@ defaults:
   tools:
     atlantis:
       enabled: true
+      module_prefixes:
+        - terraform/modules/
+        - foo_modules/
       version: 3
       automerge: true
       parallel_plan: true
@@ -39,6 +42,7 @@ envs:
               - tags
               - banana
           - source: "terraform/modules/my_module"
+          - source: "foo_modules/bar"
 modules:
   my_module: {}
 version: 2

--- a/testdata/v2_tf_registry_module_atlantis/terraform/envs/test/vpc/main.tf
+++ b/testdata/v2_tf_registry_module_atlantis/terraform/envs/test/vpc/main.tf
@@ -16,3 +16,7 @@ module "vpc" {
 module "my_module" {
   source = "../../../modules/my_module"
 }
+
+module "bar" {
+  source = "../../../../foo_modules/bar"
+}

--- a/testdata/v2_tf_registry_module_atlantis/terraform/envs/test/vpc/outputs.tf
+++ b/testdata/v2_tf_registry_module_atlantis/terraform/envs/test/vpc/outputs.tf
@@ -657,3 +657,4 @@ output "vpc_secondary_cidr_blocks" {
   sensitive = false
 }
 # module "my_module" outputs
+# module "bar" outputs

--- a/testdata/v2_tf_registry_module_atlantis_dup_module/atlantis.yaml
+++ b/testdata/v2_tf_registry_module_atlantis_dup_module/atlantis.yaml
@@ -11,7 +11,8 @@ projects:
       when_modified:
         - '*.tf'
         - '!remote-states.tf'
-        - ../../../modules/my_module/**/*.tf
+        - ../../../../terraform/modules/my_module/**/*.tf
+        - ../../../../terraform/modules/my_module/**/*.tf.json
       enabled: true
     apply_requirements:
       - approved


### PR DESCRIPTION
With the introduction of CDKTF (`*.tf.json`) and separation of Terraform module source paths,
Fogg Atlantis integration does not generate auto plan triggers for matching the new patterns.

Adding call to `os.Stat()` to detect if moduleSource is an existing path doesn't work due to:

1. plan/ci step runs before any changes are made in fs
1. moduleSource is relative to component nested path, complicating path checking logic

As an alternative solution, a new `module_prefixes` field was added to the Atlantis configuration,
defaulting to the original [`terraform/modules/`] prefix for backwards compatibility.

`*.tf.json` globbing pattern was also added to the fogg generated atlantis config file.

fixed:
- #248 
