### PR TITLE
feat: update aws arn role block

### DIFF
--- a/templates/templates/common/backends.tmpl
+++ b/templates/templates/common/backends.tmpl
@@ -7,7 +7,9 @@
     encrypt = true
     region = "{{ .S3.Region }}"
     {{if .S3.Profile}}profile = "{{ .S3.Profile }}"{{end }}
-    {{if .S3.RoleArn}}role_arn = "{{ .S3.RoleArn }}"{{end }}
+    {{if .S3.RoleArn}}assume_role = {
+      role_arn = "{{ .S3.RoleArn }}"
+    }{{end }}
   {{ else if eq .Kind "remote" }}
     hostname = "{{ .Remote.HostName }}"
     organization = "{{ .Remote.Organization }}"
@@ -25,7 +27,9 @@
     key            = "{{ .S3.KeyPath }}"
     region = "{{ .S3.Region }}"
     {{if .S3.Profile}}profile = "{{ .S3.Profile }}"{{end }}
-    {{if .S3.RoleArn}}role_arn = "{{ .S3.RoleArn }}"{{end }}
+    {{if .S3.RoleArn}}assume_role = {
+      role_arn = "{{ .S3.RoleArn }}"
+    }{{end }}
   {{ else if eq .Kind "remote" }}
     hostname = "{{ .Remote.HostName }}"
     organization = "{{ .Remote.Organization }}"

--- a/testdata/v2_atlantis_depends_on/fogg.yml
+++ b/testdata/v2_atlantis_depends_on/fogg.yml
@@ -1,7 +1,8 @@
 defaults:
   backend:
     bucket: buck
-    profile: profile
+    role: role
+    account_id: "12345"
     region: us-west-2
   extra_vars:
     foo: bar1

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/db/Makefile
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/db/Makefile
@@ -7,8 +7,8 @@ export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
 
-export AWS_BACKEND_PROFILE := profile
 
+export AWS_BACKEND_ROLE_ARN := arn:aws:iam::12345:role/role
 
 export AWS_PROVIDER_PROFILE := profile
 

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/db/fogg.tf
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/db/fogg.tf
@@ -21,8 +21,10 @@ terraform {
     key     = "terraform/proj/envs/test/components/db.tfstate"
     encrypt = true
     region  = "us-west-2"
-    profile = "profile"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
   required_providers {

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/db/remote-states.tf
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/db/remote-states.tf
@@ -8,10 +8,12 @@ data "terraform_remote_state" "global" {
 
     bucket = "buck"
 
-    key     = "terraform/proj/global.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
+    key    = "terraform/proj/global.tfstate"
+    region = "us-west-2"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
 }
@@ -23,10 +25,12 @@ data "terraform_remote_state" "vpc" {
 
     bucket = "buck"
 
-    key     = "terraform/proj/envs/test/components/vpc.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
+    key    = "terraform/proj/envs/test/components/vpc.tfstate"
+    region = "us-west-2"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
 }

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/Makefile
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/Makefile
@@ -7,8 +7,8 @@ export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../../../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
 
-export AWS_BACKEND_PROFILE := profile
 
+export AWS_BACKEND_ROLE_ARN := arn:aws:iam::12345:role/role
 
 export AWS_PROVIDER_PROFILE := profile
 

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/fogg.tf
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/fogg.tf
@@ -21,8 +21,10 @@ terraform {
     key     = "terraform/proj/envs/test/components/vpc.tfstate"
     encrypt = true
     region  = "us-west-2"
-    profile = "profile"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
   required_providers {

--- a/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/remote-states.tf
+++ b/testdata/v2_atlantis_depends_on/terraform/envs/test/vpc/remote-states.tf
@@ -8,10 +8,12 @@ data "terraform_remote_state" "global" {
 
     bucket = "buck"
 
-    key     = "terraform/proj/global.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
+    key    = "terraform/proj/global.tfstate"
+    region = "us-west-2"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
 }
@@ -23,10 +25,12 @@ data "terraform_remote_state" "db" {
 
     bucket = "buck"
 
-    key     = "terraform/proj/envs/test/components/db.tfstate"
-    region  = "us-west-2"
-    profile = "profile"
+    key    = "terraform/proj/envs/test/components/db.tfstate"
+    region = "us-west-2"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
 }

--- a/testdata/v2_atlantis_depends_on/terraform/global/Makefile
+++ b/testdata/v2_atlantis_depends_on/terraform/global/Makefile
@@ -7,8 +7,8 @@ export TFLINT_ENABLED := 0
 export TF_PLUGIN_CACHE_DIR := ../..//.terraform.d/plugin-cache
 export TF_BACKEND_KIND := s3
 
-export AWS_BACKEND_PROFILE := profile
 
+export AWS_BACKEND_ROLE_ARN := arn:aws:iam::12345:role/role
 
 export AWS_PROVIDER_PROFILE := profile
 

--- a/testdata/v2_atlantis_depends_on/terraform/global/fogg.tf
+++ b/testdata/v2_atlantis_depends_on/terraform/global/fogg.tf
@@ -21,8 +21,10 @@ terraform {
     key     = "terraform/proj/global.tfstate"
     encrypt = true
     region  = "us-west-2"
-    profile = "profile"
 
+    assume_role = {
+      role_arn = "arn:aws:iam::12345:role/role"
+    }
 
   }
   required_providers {


### PR DESCRIPTION
fixes:
- #266 

This PR modifies the aws arn_role within the s3 backend config. The aws arn_role has been updated with a nested format. This allows follows the updated arn_role format and eliminate the deprecated warnings.
