### PR TITLE
chore: bootstrap releases for path: .

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
         id: release
         with:
           release-type: simple
-          bump-minor-pre-major: true
-          changelog-types: ${{ steps.configure-changelog.outputs.result }}
           # https://github.com/google-github-actions/release-please-action#github-credentials
           token: ${{ secrets.VINCENT_PAT }}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "simple",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,14 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features", "hidden": false },
+        { "type": "chore", "section": "Misc", "hidden": false },
+        { "type": "fix", "section": "BugFixes", "hidden": false }
+      ]
     }
   },
+  "bootstrap-sha": "df05ed5f16a6da3f3694e93ad04370a9c16188b0",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
Configuring release-please for path: .

```console
export GITHUB_TOKEN=$(gh auth token)
release-please bootstrap --repo-url $(git remote get-url fork) --release-type simple --target-branch feat-multi-module-components --bump-minor-pre-major --bump-patch-for-minor-pre-major --token ${GITHUB_TOKEN}
```

Ref:

- [bootstrapping](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrapping)
