### PR TITLE
ci: Review release please config

### DIFF
--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const validator = /^(chore|feat|fix|revert|docs|style)(\((((PETI|HSENG|SAENG)-[0-9]+)|([a-z-]+))\))?(!)?: (.)+$/
+            const validator = /^(chore|feat|fix|revert|docs|style|ci)(\((((PETI|HSENG|SAENG)-[0-9]+)|([a-z-]+))\))?(!)?: (.)+$/
             const title = context.payload.pull_request.title
             const is_valid = validator.test(title)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,24 +8,10 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
-        id: configure-changelog
-        with:
-          result-encoding: string
-          script: |
-            const changelogTypes = [
-              {type: "feat", section: "Features", hidden: false},
-              {type: "chore", section: "Misc", hidden: false},
-              {type: "fix", section: "BugFixes", hidden: false},
-            ]
-
-            return JSON.stringify(changelogTypes)
-
       - name: release please
         uses: google-github-actions/release-please-action@v4.1.0
         id: release
         with:
-          release-type: simple
           # https://github.com/google-github-actions/release-please-action#github-credentials
           token: ${{ secrets.VINCENT_PAT }}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,10 +10,10 @@
       "changelog-sections": [
         { "type": "feat", "section": "Features", "hidden": false },
         { "type": "chore", "section": "Misc", "hidden": false },
+        { "type": "ci", "section": "Continuous Integration", "hidden": false },
         { "type": "fix", "section": "BugFixes", "hidden": false }
       ]
     }
   },
-  "bootstrap-sha": "df05ed5f16a6da3f3694e93ad04370a9c16188b0",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
- Do not set `release-type` on github action to ensure manifest is used
- Clean up changelog config from GH Workflow as it is maintained in release-please-config file
- Test adding new changelog section configuration
- Clean up bootstrap-sha as it is ignored after initial bootstrap

Ref:

- [command](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#command)
- [bootstrap](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#starting-commit)
