### PR TITLE
ci: Fix go 1.22 caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          # go-version-file: go.mod
+          go-version: "1.22"
       - name: Run tests
         run: make test-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          # go-version-file: go.mod
+          go-version: "1.22"
         if: ${{ steps.release.outputs.release_created }}
 
       - name: Run GoReleaser


### PR DESCRIPTION
switch off of `go-version-file` in the Github Actions, because it doesn't work great with the new `go mod tidy` format that go 1.22 does. See:

* [Improve toolchain handling actions/setup-go#460](https://github.com/actions/setup-go/pull/460)
* [More specific handling/detection of Go toolchain versions actions/setup-go#457](https://github.com/actions/setup-go/issues/457)

Also related:
- https://github.com/actions/setup-go/issues/424
