### PR TITLE
fix: Guarantee autoplan order

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -493,6 +493,8 @@ func applyAtlantisConfig(base afero.Fs, atlantisFs fs.FS, common fs.FS, targetBa
 				),
 			)
 		}
+		// sort whenModified to avoid spurious diffs
+		sort.Strings(whenModified)
 		project.Autoplan.WhenModified = whenModified
 	}
 	err := applyTree(base, atlantisFs, common, targetBasePath, config)

--- a/testdata/v2_atlantis_depends_on/atlantis.yaml
+++ b/testdata/v2_atlantis_depends_on/atlantis.yaml
@@ -10,9 +10,9 @@ projects:
     autoplan:
       when_modified:
         - '*.tf'
-        - ../../foo.yaml
         - ../../../modules/my_module/**/*.tf
         - ../../../modules/my_module/**/*.tf.json
+        - ../../foo.yaml
       enabled: true
     apply_requirements:
       - approved
@@ -22,16 +22,16 @@ projects:
     terraform_version: 0.100.0
     autoplan:
       when_modified:
-        - '*.tf'
         - '!remote-states.tf'
-        - ../../../../foo_modules/parent_module/**/*.tf
-        - ../../../../foo_modules/parent_module/**/*.tf.json
+        - '*.tf'
         - ../../../../foo_modules/nested_module1/**/*.tf
         - ../../../../foo_modules/nested_module1/**/*.tf.json
         - ../../../../foo_modules/nested_module2/**/*.tf
         - ../../../../foo_modules/nested_module2/**/*.tf.json
         - ../../../../foo_modules/nested_module3/**/*.tf
         - ../../../../foo_modules/nested_module3/**/*.tf.json
+        - ../../../../foo_modules/parent_module/**/*.tf
+        - ../../../../foo_modules/parent_module/**/*.tf.json
       enabled: true
     apply_requirements:
       - approved
@@ -41,12 +41,12 @@ projects:
     terraform_version: 0.100.0
     autoplan:
       when_modified:
-        - '*.tf'
         - '!remote-states.tf'
-        - ../../../modules/my_module/**/*.tf
-        - ../../../modules/my_module/**/*.tf.json
+        - '*.tf'
         - ../../../../foo_modules/bar/**/*.tf
         - ../../../../foo_modules/bar/**/*.tf.json
+        - ../../../modules/my_module/**/*.tf
+        - ../../../modules/my_module/**/*.tf.json
       enabled: true
     apply_requirements:
       - approved

--- a/testdata/v2_tf_registry_module_atlantis/atlantis.yaml
+++ b/testdata/v2_tf_registry_module_atlantis/atlantis.yaml
@@ -9,12 +9,12 @@ projects:
     terraform_version: 0.100.0
     autoplan:
       when_modified:
-        - '*.tf'
         - '!remote-states.tf'
-        - ../../../modules/my_module/**/*.tf
-        - ../../../modules/my_module/**/*.tf.json
+        - '*.tf'
         - ../../../../foo_modules/bar/**/*.tf
         - ../../../../foo_modules/bar/**/*.tf.json
+        - ../../../modules/my_module/**/*.tf
+        - ../../../modules/my_module/**/*.tf.json
       enabled: true
     apply_requirements:
       - approved

--- a/testdata/v2_tf_registry_module_atlantis_dup_module/atlantis.yaml
+++ b/testdata/v2_tf_registry_module_atlantis_dup_module/atlantis.yaml
@@ -9,8 +9,8 @@ projects:
     terraform_version: 0.100.0
     autoplan:
       when_modified:
-        - '*.tf'
         - '!remote-states.tf'
+        - '*.tf'
         - ../../../modules/my_module/**/*.tf
         - ../../../modules/my_module/**/*.tf.json
       enabled: true


### PR DESCRIPTION
Sort whenModified array to fix flaky test failures due to use of `map` iterations
