### PR TITLE
fix: Remove gorelease deprecations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.VINCENT_PAT }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
- `--rm-dist` has been deprecated in favour of `--clean` [Reference](https://goreleaser.com/deprecations/#-rm-dist)

Ref:

- https://github.com/chanzuckerberg/fogg/pull/1018
