### PR TITLE
feat: Add --affected flag for turbo synth

### DIFF
--- a/config/v2/config.go
+++ b/config/v2/config.go
@@ -576,6 +576,7 @@ type TurboConfig struct {
 	Enabled  *bool   `yaml:"enabled,omitempty"`   // Enable Turbo, default: false
 	Version  *string `yaml:"version,omitempty"`   // Optional Turbo version, default: "^2.0.6"
 	RootName *string `yaml:"root_name,omitempty"` // Optional Name for the root package, default: "fogg-monorepo"
+	SCMBase  *string `yaml:"scm_base,omitempty"`  // Optional Git comparison base override, default: "main"
 
 	DevDependencies []JavascriptDependency `yaml:"dev_dependencies,omitempty"` // Optional additional root dev dependencies, default: []
 }

--- a/plan/ci.go
+++ b/plan/ci.go
@@ -52,6 +52,7 @@ type TurboConfig struct {
 	Enabled         bool
 	Version         string
 	RootName        string
+	SCMBase         string
 	DevDependencies map[string]string
 	CdktfPackages   []string
 }
@@ -390,6 +391,7 @@ func (p *Plan) buildGitHubActionsConfig(c *v2.Config, foggVersion string) GitHub
 func (p *Plan) buildTurboRootConfig(c *v2.Config) *TurboConfig {
 	turboConfig := &TurboConfig{
 		Enabled:  false,
+		SCMBase:  "main",
 		RootName: "fogg-monorepo",
 		DevDependencies: map[string]string{
 			"@types/node":  "^20.6.0",
@@ -403,6 +405,10 @@ func (p *Plan) buildTurboRootConfig(c *v2.Config) *TurboConfig {
 	if c.Turbo != nil {
 		if c.Turbo.Enabled != nil {
 			turboConfig.Enabled = *c.Turbo.Enabled
+		}
+
+		if c.Turbo.SCMBase != nil {
+			turboConfig.SCMBase = *c.Turbo.SCMBase
 		}
 
 		if c.Turbo.Version != nil {

--- a/templates/templates/turbo/root/package.json.tmpl
+++ b/templates/templates/turbo/root/package.json.tmpl
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "synth": "turbo run synth"
+    "synth": "TURBO_SCM_BASE='{{ .SCMBase }}' turbo run synth --affected"
   },
   "engines": {
     "node": "20"

--- a/testdata/v2_cdktf_components/package.json
+++ b/testdata/v2_cdktf_components/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "synth": "turbo run synth"
+    "synth": "TURBO_SCM_BASE='main' turbo run synth --affected"
   },
   "engines": {
     "node": "20"


### PR DESCRIPTION
Improve synth performance using turbo integration with SCM

Turbo docs:
- https://turbo.build/repo/docs/reference/run#--affected

> NOTE: When used with Atlantis, requires modifying `--checkout-depth`(default is shallow clone). 
