### PR TITLE
fix: CodeArtifact login should include scope

### DIFF
--- a/plan/ci_test.go
+++ b/plan/ci_test.go
@@ -353,9 +353,10 @@ func Test_parseScopes(t *testing.T) {
 		r.Equal("https://domain-123456789012.d.codeartifact.us-west-2.amazonaws.com/npm/repo-name/", (*result)["@scope3"].RegistryUrl)
 		r.Equal("https://domain-123456789012.d.codeartifact.us-east-1.amazonaws.com/npm/repo-name/", (*result)["@scope4"].RegistryUrl)
 		r.Equal("https://domain-210987654321.d.codeartifact.us-west-2.amazonaws.com/npm/repo-name/", (*result)["@scope5"].RegistryUrl)
-		expectedScript := "aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-east-1;" +
-			"aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2;" +
-			"aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 210987654321 --region us-west-2"
+		expectedScript := `aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-east-1 --namespace "@scope4";` +
+			`aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2 --namespace "@scope2";` +
+			`aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2 --namespace "@scope3";` +
+			`aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 210987654321 --region us-west-2 --namespace "@scope5"`
 		r.Equal(expectedScript, script)
 	})
 
@@ -372,6 +373,6 @@ func Test_parseScopes(t *testing.T) {
 		r.Len(*result, 2)
 		r.Equal("https://registry.npmjs.org", (*result)["@scope1"].RegistryUrl)
 		r.Equal("https://domain-123456789012.d.codeartifact.us-west-2.amazonaws.com/npm/repo-name/", (*result)["@scope2"].RegistryUrl)
-		r.Contains(script, "aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2")
+		r.Contains(script, `aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2 --namespace "@scope2"`)
 	})
 }

--- a/templates/templates/turbo/root/package.json.tmpl
+++ b/templates/templates/turbo/root/package.json.tmpl
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "ca:login": "{{ .CodeArtifactLoginScript }}",
+    "ca:login": {{ .CodeArtifactLoginScript | quote}},
     "test": "turbo test",
     "synth": "TURBO_SCM_BASE='{{ .SCMBase }}' turbo run synth --affected",
     "type-check": "turbo type-check",

--- a/testdata/v2_cdktf_components/package.json
+++ b/testdata/v2_cdktf_components/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "ca:login": "aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2",
+    "ca:login": "aws codeartifact login --tool npm --repository repo-name --domain domain --domain-owner 123456789012 --region us-west-2 --namespace \"@myorg\"",
     "test": "turbo test",
     "synth": "TURBO_SCM_BASE='main' turbo run synth --affected",
     "type-check": "turbo type-check",

--- a/util/codeartifact.go
+++ b/util/codeartifact.go
@@ -21,11 +21,20 @@ type CodeArtifactRepository struct {
 	AccountId string
 	Region    string
 	Name      string
+	Namespace string
+}
+
+// Returns the `aws codeartifact login` command for the repository with the given `scope`.
+//
+// refer to https://docs.aws.amazon.com/codeartifact/latest/ug/npm-auth.html#configure-npm-login-command
+func (r *CodeArtifactRepository) LoginCommand() string {
+	return fmt.Sprintf("aws codeartifact login --tool npm --repository %s --domain %s --domain-owner %s --region %s --namespace %q",
+		r.Name, r.Domain, r.AccountId, r.Region, r.Namespace)
 }
 
 // Gets AWS details from the Code Artifact `registryUrl`.
 // throws exception if not matching expected pattern
-func ParseRegistryUrl(registryUrl string) (*CodeArtifactRepository, error) {
+func ParseRegistryUrl(scope string, registryUrl string) (*CodeArtifactRepository, error) {
 	// https://github.com/projen/projen/blob/v0.91.4/src/javascript/util.ts#L48
 	regex := regexp.MustCompile(AWS_CODEARTIFACT_CAPTURE_REGEX)
 	matches := regex.FindStringSubmatch(registryUrl)
@@ -37,5 +46,6 @@ func ParseRegistryUrl(registryUrl string) (*CodeArtifactRepository, error) {
 		AccountId: matches[2],
 		Region:    matches[3],
 		Name:      matches[4],
+		Namespace: scope,
 	}, nil
 }

--- a/util/codeartifact_test.go
+++ b/util/codeartifact_test.go
@@ -8,23 +8,27 @@ import (
 func Test_ParseRegistryUrl(t *testing.T) {
 	tests := []struct {
 		name    string
+		scope   string
 		url     string
 		want    *CodeArtifactRepository
 		wantErr bool
 	}{
 		{
-			name: "Valid CodeArtifact Repository URL",
-			url:  "https://vincenthsh-123456789.d.codeartifact.ap-southeast-1.amazonaws.com/npm/npm-releases/",
+			name:  "Valid CodeArtifact Repository URL",
+			scope: "@foo",
+			url:   "https://vincenthsh-123456789.d.codeartifact.ap-southeast-1.amazonaws.com/npm/npm-releases/",
 			want: &CodeArtifactRepository{
 				Domain:    "vincenthsh",
 				AccountId: "123456789",
 				Region:    "ap-southeast-1",
 				Name:      "npm-releases",
+				Namespace: "@foo",
 			},
 			wantErr: false,
 		},
 		{
 			name:    "Invalid CodeArtifact URL",
+			scope:   "@foo",
 			url:     "https://example.com",
 			want:    nil,
 			wantErr: true,
@@ -33,7 +37,7 @@ func Test_ParseRegistryUrl(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseRegistryUrl(tt.url)
+			got, err := ParseRegistryUrl(tt.scope, tt.url)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseRegistryUrl() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Without the `--namespace` flag, the command forces all traffic through the CA Domain
