### PR TITLE
fix: remotestateproxy output wrappers bug

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -722,7 +722,7 @@ func (p *Plan) buildEnvs(conf *v2.Config) (map[string]Env, error) {
 			componentPlan.PathToRepoRoot = "../../../../"
 			componentPlan.CdktfDependencies = map[string]string{
 				// from packages/cdktf-fogg-constructs
-				"@vincenthsh/cdktf-fogg-helpers": "^1.4.0",
+				"@vincenthsh/cdktf-fogg-helpers": "^1.4.1",
 				"@cdktf/provider-aws":            "^19.50.0", // @vincenthsh/cdktf-fogg-helpers peer dependency
 				"@cdktf/provider-cloudflare":     "^11.29.0", // @vincenthsh/cdktf-fogg-helpers peer dependency
 				"@cdktf/provider-datadog":        "^11.17.2", // @vincenthsh/cdktf-fogg-helpers peer dependency

--- a/testdata/v2_cdktf_components/terraform/envs/test/lambda/.fogg-component.yaml
+++ b/testdata/v2_cdktf_components/terraform/envs/test/lambda/.fogg-component.yaml
@@ -107,7 +107,7 @@ cdktf_dependencies:
     '@cdktf/provider-datadog': ^11.17.2
     '@myorg/my-cdktf-constructs': ^1.0.0
     '@types/aws-lambda': ^8.10.76
-    '@vincenthsh/cdktf-fogg-helpers': ^1.4.0
+    '@vincenthsh/cdktf-fogg-helpers': ^1.4.1
     cdktf: ^0.20.11
     constructs: ^10.4.0
     esbuild-wasm: ^0.23.0

--- a/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
@@ -18,7 +18,7 @@
     "@cdktf/provider-datadog": "^11.17.2",
     "@myorg/my-cdktf-constructs": "^1.0.0",
     "@types/aws-lambda": "^8.10.76",
-    "@vincenthsh/cdktf-fogg-helpers": "^1.4.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^1.4.1",
     "cdktf": "^0.20.11",
     "constructs": "^10.4.0",
     "esbuild-wasm": "^0.23.0",

--- a/testdata/v2_cdktf_components/terraform/envs/test/network/.fogg-component.yaml
+++ b/testdata/v2_cdktf_components/terraform/envs/test/network/.fogg-component.yaml
@@ -147,7 +147,7 @@ cdktf_dependencies:
     '@cdktf/provider-aws': ^19.50.0
     '@cdktf/provider-cloudflare': ^11.29.0
     '@cdktf/provider-datadog': ^11.17.2
-    '@vincenthsh/cdktf-fogg-helpers': ^1.4.0
+    '@vincenthsh/cdktf-fogg-helpers': ^1.4.1
     cdktf: ^0.20.11
     constructs: ^10.4.0
 cdktf_dev_dependencies:

--- a/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
@@ -16,7 +16,7 @@
     "@cdktf/provider-aws": "^19.50.0",
     "@cdktf/provider-cloudflare": "^11.29.0",
     "@cdktf/provider-datadog": "^11.17.2",
-    "@vincenthsh/cdktf-fogg-helpers": "^1.4.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^1.4.1",
     "cdktf": "^0.20.11",
     "constructs": "^10.4.0"
   },

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
@@ -106,7 +106,7 @@ cdktf_dependencies:
     '@cdktf/provider-cloudflare': ^11.29.0
     '@cdktf/provider-datadog': ^11.17.2
     '@types/aws-lambda': ^8.10.76
-    '@vincenthsh/cdktf-fogg-helpers': ^1.4.0
+    '@vincenthsh/cdktf-fogg-helpers': ^1.4.1
     cdktf: ^0.20.11
     constructs: ^10.4.0
     terraconstructs: ^0.0.11

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
@@ -17,7 +17,7 @@
     "@cdktf/provider-cloudflare": "^11.29.0",
     "@cdktf/provider-datadog": "^11.17.2",
     "@types/aws-lambda": "^8.10.76",
-    "@vincenthsh/cdktf-fogg-helpers": "^1.4.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^1.4.1",
     "cdktf": "^0.20.11",
     "constructs": "^10.4.0",
     "terraconstructs": "^0.0.11"


### PR DESCRIPTION
The remote state proxy strongly typed wrappers would cause type bug, clarify
the interface.

(this breaks the interface from 1.4.0, but the old interface was not working, so patch bump it is)
