### PR TITLE
fix: use swc for component synth scripts

### DIFF
--- a/templates/templates/component/cdktf/package.json.tmpl
+++ b/templates/templates/component/cdktf/package.json.tmpl
@@ -8,7 +8,7 @@
     "ca:login": "pnpm -w run ca:login",
     "lint": "eslint",
     "prettier": "prettier --write .",
-    "synth": "ts-node -P ./tsconfig.json src/index.ts",
+    "synth": "ts-node --swc -P ./tsconfig.json src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf coverage"
   },

--- a/templates/templates/component/terraconstructs/package.json.tmpl
+++ b/templates/templates/component/terraconstructs/package.json.tmpl
@@ -8,7 +8,7 @@
     "ca:login": "pnpm -w run ca:login",
     "lint": "eslint",
     "prettier": "prettier --write .",
-    "synth": "ts-node -P ./tsconfig.json src/index.ts",
+    "synth": "ts-node --swc -P ./tsconfig.json src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf coverage"
   },

--- a/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
@@ -8,7 +8,7 @@
     "ca:login": "pnpm -w run ca:login",
     "lint": "eslint",
     "prettier": "prettier --write .",
-    "synth": "ts-node -P ./tsconfig.json src/index.ts",
+    "synth": "ts-node --swc -P ./tsconfig.json src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf coverage"
   },

--- a/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
@@ -8,7 +8,7 @@
     "ca:login": "pnpm -w run ca:login",
     "lint": "eslint",
     "prettier": "prettier --write .",
-    "synth": "ts-node -P ./tsconfig.json src/index.ts",
+    "synth": "ts-node --swc -P ./tsconfig.json src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf coverage"
   },

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
@@ -8,7 +8,7 @@
     "ca:login": "pnpm -w run ca:login",
     "lint": "eslint",
     "prettier": "prettier --write .",
-    "synth": "ts-node -P ./tsconfig.json src/index.ts",
+    "synth": "ts-node --swc -P ./tsconfig.json src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf coverage"
   },


### PR DESCRIPTION
Seems this was missed by mistake as the `@swc/core` dev dependency was there, but the flag was missed on ts-node

Ref: [SWC Support built-in for ts-node](https://typestrong.org/ts-node/docs/swc/)
