### PR TITLE
fix: add GITHUB_TOKEN as env var for pre-commit hook

### DIFF
--- a/templates/templates/.github/workflows/fogg_ci.yml.tmpl
+++ b/templates/templates/.github/workflows/fogg_ci.yml.tmpl
@@ -54,6 +54,8 @@ jobs:
           FOGG_GITHUBTOKEN: {{`${{ secrets.GITHUB_TOKEN }}`}}
       # run full pre-commit
       - run: {{ list "pre-commit run --show-diff-on-failure --color=always" ($githubActionsCI.PreCommit.ExtraArgs | join " ") | join " " }}
+        env:
+          GITHUB_TOKEN: {{`${{ secrets.GITHUB_TOKEN }}`}}
       {{- else }}
       - run: fogg apply
         env:

--- a/testdata/v2_github_actions_with_pre_commit/.github/workflows/fogg_ci.yml
+++ b/testdata/v2_github_actions_with_pre_commit/.github/workflows/fogg_ci.yml
@@ -54,3 +54,5 @@ jobs:
           FOGG_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
       # run full pre-commit
       - run: pre-commit run --show-diff-on-failure --color=always --all-files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Error on Pull Request that exceed GITHUB API limit
https://github.com/HandshakesByDC/terraform.handshakes.liftandshift/actions/runs/16410377242/job/46364772547#step:14:63

- un-authenticated user has 60 requests per hour
- authenticated user has up to 5000 request per hour

ref: https://dev.to/codexam/github-api-rate-limit-exceeded-problem-502f

fix: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
To increase the rate limit, you can send an authenticated request by authenticating your requests with an access token, by setting the `GITHUB_TOKEN` environment variable. In GitHub Actions, you can pass the built-in GITHUB_TOKEN that is injected into each job.
