### PR TITLE
fix: Add missing assignment for required_providers source field

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -1304,6 +1304,7 @@ func resolveComponentCommon(commons ...v2.Common) ComponentCommon {
 					CustomProvider: customProvider,
 					Version:        version,
 				},
+				Source: rp.Source,
 				Config: rp.Config,
 			}
 

--- a/testdata/v2_terraconstruct_components/fogg.yml
+++ b/testdata/v2_terraconstruct_components/fogg.yml
@@ -37,6 +37,10 @@ envs:
               enabled: true
               tags:
                 team: TIES
+        required_providers:
+          cloudflare:
+            source: cloudflare/cloudflare
+            version: "~> 4.0"
         kind: terraconstruct # required to ensure AwsStack is extended
         cdktf_dependencies:
           - name: "@types/aws-lambda"

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
@@ -74,7 +74,12 @@ providers_configuration:
     snowflake: null
     tfe: null
     sops: null
-required_providers: {}
+required_providers:
+    cloudflare:
+        enabled: true
+        version: ~> 4.0
+        source: cloudflare/cloudflare
+        config: {}
 provider_versions:
     archive:
         source: hashicorp/archive
@@ -85,6 +90,9 @@ provider_versions:
     aws:
         source: hashicorp/aws
         version: 0.12.0
+    cloudflare:
+        source: cloudflare/cloudflare
+        version: ~> 4.0
     local:
         source: hashicorp/local
         version: ~> 2.0


### PR DESCRIPTION
Plan environment build missed copying over the fogg config for generic
providers to include the source field
