### PR TITLE
fix: turbo --affected cdktf synth issues

### DIFF
--- a/templates/templates/turbo/root/turbo.json.tmpl
+++ b/templates/templates/turbo/root/turbo.json.tmpl
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+        "inputs": ["src/**/*", ".fogg-component.yaml"],
         "outputs": ["dist/**"],
         "dependsOn": ["^build"]
     },

--- a/testdata/v2_cdktf_components/turbo.json
+++ b/testdata/v2_cdktf_components/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+        "inputs": ["src/**/*", ".fogg-component.yaml"],
         "outputs": ["dist/**"],
         "dependsOn": ["^build"]
     },

--- a/testdata/v2_terraconstruct_components/turbo.json
+++ b/testdata/v2_terraconstruct_components/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+        "inputs": ["src/**/*", ".fogg-component.yaml"],
         "outputs": ["dist/**"],
         "dependsOn": ["^build"]
     },


### PR DESCRIPTION
Currently synth depends on build which uses the turbo default inputs
(including pnpm lock file). By overriding the inputs for the build task
this may solve full repo synth whenever a new component is added.
