### PR TITLE
fix: pin generated components to @vincenthsh/cdktf-fogg-helpers ^3.0.0

### DIFF
--- a/.github/workflows/force-publish.yml
+++ b/.github/workflows/force-publish.yml
@@ -1,0 +1,61 @@
+name: force-publish
+
+# Manually (re-)publish workspace npm packages out-of-band from release-please.
+#
+# Why this exists: the `release-please` workflow gates publishing on
+# `steps.release.outputs.release_created`, which is only true the first time a
+# release PR merges. If `pnpm publish` itself fails (e.g. a bad/expired
+# NPM_TOKEN), re-running that job does NOT re-publish — release-please reports
+# the release already exists and every downstream step is skipped. This
+# workflow lets you force the publish after fixing the token, opting in per
+# package, with a dry-run guard on by default.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdktf_fogg_helpers:
+        description: "Publish @vincenthsh/cdktf-fogg-helpers"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run (pack only, no publish). Uncheck to actually publish."
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  force-publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup pnpm from .packageManager
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish @vincenthsh/cdktf-fogg-helpers
+        if: ${{ inputs.cdktf_fogg_helpers }}
+        run: >-
+          pnpm --filter @vincenthsh/cdktf-fogg-helpers publish
+          --no-git-checks
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          # setup-node writes the auth-configured .npmrc; pnpm falls back to this
+          # token when OIDC trusted publishing is not available.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -723,7 +723,7 @@ func (p *Plan) buildEnvs(conf *v2.Config) (map[string]Env, error) {
 			componentPlan.PathToRepoRoot = "../../../../"
 			componentPlan.CdktfDependencies = map[string]string{
 				// from packages/cdktf-fogg-constructs
-				"@vincenthsh/cdktf-fogg-helpers": "^2.0.0",
+				"@vincenthsh/cdktf-fogg-helpers": "^3.0.0",
 				"@cdktn/provider-aws":            "^24.8.0", // @vincenthsh/cdktf-fogg-helpers peer dependency (AWS provider v6)
 				"@cdktn/provider-cloudflare":     "^15.2.1", // @vincenthsh/cdktf-fogg-helpers peer dependency
 				"@cdktn/provider-datadog":        "^15.4.0", // @vincenthsh/cdktf-fogg-helpers peer dependency

--- a/testdata/v2_cdktf_components/terraform/envs/test/lambda/.fogg-component.yaml
+++ b/testdata/v2_cdktf_components/terraform/envs/test/lambda/.fogg-component.yaml
@@ -107,7 +107,7 @@ cdktf_dependencies:
     '@cdktn/provider-datadog': ^15.4.0
     '@myorg/my-cdktf-constructs': ^1.0.0
     '@types/aws-lambda': ^8.10.76
-    '@vincenthsh/cdktf-fogg-helpers': ^2.0.0
+    '@vincenthsh/cdktf-fogg-helpers': ^3.0.0
     cdktn: ^0.23.3
     constructs: ^10.6.0
     esbuild-wasm: ^0.23.0

--- a/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/lambda/package.json
@@ -18,7 +18,7 @@
     "@cdktn/provider-datadog": "^15.4.0",
     "@myorg/my-cdktf-constructs": "^1.0.0",
     "@types/aws-lambda": "^8.10.76",
-    "@vincenthsh/cdktf-fogg-helpers": "^2.0.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^3.0.0",
     "cdktn": "^0.23.3",
     "constructs": "^10.6.0",
     "esbuild-wasm": "^0.23.0",

--- a/testdata/v2_cdktf_components/terraform/envs/test/network/.fogg-component.yaml
+++ b/testdata/v2_cdktf_components/terraform/envs/test/network/.fogg-component.yaml
@@ -147,7 +147,7 @@ cdktf_dependencies:
     '@cdktn/provider-aws': ^24.8.0
     '@cdktn/provider-cloudflare': ^15.2.1
     '@cdktn/provider-datadog': ^15.4.0
-    '@vincenthsh/cdktf-fogg-helpers': ^2.0.0
+    '@vincenthsh/cdktf-fogg-helpers': ^3.0.0
     cdktn: ^0.23.3
     constructs: ^10.6.0
 cdktf_dev_dependencies:

--- a/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
+++ b/testdata/v2_cdktf_components/terraform/envs/test/network/package.json
@@ -16,7 +16,7 @@
     "@cdktn/provider-aws": "^24.8.0",
     "@cdktn/provider-cloudflare": "^15.2.1",
     "@cdktn/provider-datadog": "^15.4.0",
-    "@vincenthsh/cdktf-fogg-helpers": "^2.0.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^3.0.0",
     "cdktn": "^0.23.3",
     "constructs": "^10.6.0"
   },

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/.fogg-component.yaml
@@ -114,7 +114,7 @@ cdktf_dependencies:
     '@cdktn/provider-cloudflare': ^15.2.1
     '@cdktn/provider-datadog': ^15.4.0
     '@types/aws-lambda': ^8.10.76
-    '@vincenthsh/cdktf-fogg-helpers': ^2.0.0
+    '@vincenthsh/cdktf-fogg-helpers': ^3.0.0
     cdktn: ^0.23.3
     constructs: ^10.6.0
     terraconstructs: ^0.2.5

--- a/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
+++ b/testdata/v2_terraconstruct_components/terraform/envs/test/lambda/package.json
@@ -17,7 +17,7 @@
     "@cdktn/provider-cloudflare": "^15.2.1",
     "@cdktn/provider-datadog": "^15.4.0",
     "@types/aws-lambda": "^8.10.76",
-    "@vincenthsh/cdktf-fogg-helpers": "^2.0.0",
+    "@vincenthsh/cdktf-fogg-helpers": "^3.0.0",
     "cdktn": "^0.23.3",
     "constructs": "^10.6.0",
     "terraconstructs": "^0.2.5"


### PR DESCRIPTION
Bundles the helper version-skew fix with a force-publish workflow.

## fix: helper pin ^2.0.0 → ^3.0.0 (release-triggering)

release-please bumped `@vincenthsh/cdktf-fogg-helpers` **1.5.2 → 3.0.0** (the manual `2.0.0` manifest bump + the breaking cdktn migration `feat!` → major, skipping 2.0.0). But `plan.go` still pinned `^2.0.0`, which matches **neither** the published `1.5.2` nor `3.0.0` → `fogg apply` output would fail `pnpm install` for every consumer. Bumped the pin to `^3.0.0` + regenerated golden. This `fix:` cuts a fogg **0.93.1** release-please PR.

## ci: force-publish workflow_dispatch

`release-please.yml` gates publishing on `release_created`, which is `false` on re-run once the release exists — so when `pnpm publish` fails (the `NPM_TOKEN` 404 that blocked `@vincenthsh/cdktf-fogg-helpers@3.0.0`), re-running cannot re-publish. This `workflow_dispatch`:
- opt-in **per package** (`@vincenthsh/cdktf-fogg-helpers`; `@vincenthsh/tsconfig` is `private`),
- **dry-run ON by default** (uncheck to publish),
- token auth via `secrets.NPM_TOKEN`, mirroring `release.yml`.

**Use:** after merge → Actions → force-publish → check the package, uncheck Dry run, Run. (`workflow_dispatch` only appears once the file is on the default branch.)

## Order of operations
1. Merge this PR (publishes nothing yet; cuts the 0.93.1 release PR).
2. Run **force-publish** to push `@vincenthsh/cdktf-fogg-helpers@3.0.0` with the fixed token.
3. Merge the release-please **0.93.1** PR → fogg binary now generates components pinning `^3.0.0` that resolve against the published helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)